### PR TITLE
Remove wrong assertion

### DIFF
--- a/maspsx/__init__.py
+++ b/maspsx/__init__.py
@@ -272,9 +272,6 @@ class MaspsxProcessor:
             # cannot use a mult within 2 instructions of mflo/mfhi
             res.append(line)
 
-            nop = self.get_next_instruction(skip=0)
-            assert nop == "#nop", f"#nop is expected after mfhi. Got {nop}"
-
             next_next_line = self.get_next_instruction(skip=1, ignore_set=True)
             mult = self.get_next_instruction(skip=2, ignore_set=True)
 


### PR DESCRIPTION
I found an invalid assertion that causes the error `Exception occurred: #nop is expected after mfhi. Got $L22:` to be dropped for a function that would otherwise match: https://decomp.me/scratch/xe2RY