### PR TITLE
Complete the set of instructions with two-nops afterward

### DIFF
--- a/maspsx/__init__.py
+++ b/maspsx/__init__.py
@@ -275,9 +275,8 @@ class MaspsxProcessor:
             next_next_instruction = self.get_next_instruction(
                 skip=1, ignore_nop=True, ignore_set=True, ignore_label=True
             )
-            if next_instruction.startswith("mult\t") or next_instruction.startswith(
-                "div\t"
-            ):
+            if any(next_instruction.startswith(x) for x in
+                   ["mult\t","multu\t","div\t","divu\t","mthi\t"]):
                 # #nop
                 # #nop
                 # mult...
@@ -294,9 +293,8 @@ class MaspsxProcessor:
                         res.append(inst)
                 self.skip_instructions = skip
 
-            elif next_next_instruction.startswith(
-                "mult\t"
-            ) or next_next_instruction.startswith("div\t"):
+            elif any(next_next_instruction.startswith(x) for x in
+                     ["mult\t","multu\t","div\t","divu\t","mthi\t"]):
                 # #nop
                 # #nop
                 # addu or lh ...

--- a/maspsx/__init__.py
+++ b/maspsx/__init__.py
@@ -276,7 +276,7 @@ class MaspsxProcessor:
                 skip=1, ignore_nop=True, ignore_set=True, ignore_label=True
             )
             if any(next_instruction.startswith(x) for x in
-                   ["mult\t","multu\t","div\t","divu\t","mthi\t"]):
+                   ["mult\t","multu\t","div\t","divu\t"]):
                 # #nop
                 # #nop
                 # mult...
@@ -294,7 +294,7 @@ class MaspsxProcessor:
                 self.skip_instructions = skip
 
             elif any(next_next_instruction.startswith(x) for x in
-                     ["mult\t","multu\t","div\t","divu\t","mthi\t"]):
+                     ["mult\t","multu\t","div\t","divu\t"]):
                 # #nop
                 # #nop
                 # addu or lh ...


### PR DESCRIPTION
Fixes #14.

As per the CPU manual, https://cgi.cse.unsw.edu.au/~cs3231/doc/R3000.pdf, page 258 or A-46, the MFHI instruction says 

> "To ensure proper operation in the event of interruptions, the two instructions which follow a MFHI instruction may not be any of the instructions which modify the HI register: MULT, MULTU, DIV, DIVU, MTHI."

I have taken the liberty of adding all of these instructions to the keepout section after `mflo` and `mfhi` instructions. I also used Python's `any` keyword to make the line neater.

I removed `mthi` from the set because the SOTN decomp does not use that instruction, and because `mthi` and `mtlo` would require us to separate some of the logic for handling `mflo` versus `mfhi`, rather than the combined approach that is currently used. Therefore, ultimately, all this PR does is add the unsigned versions of `mult` and `div` to the keepout-zone.

I have confirmed that, with this change in place, the sotn-decomp project compiles successfully, so this should not introduce any regressions.