### PR TITLE
Fix missing NOP before NOR instruction

### DIFF
--- a/maspsx/__init__.py
+++ b/maspsx/__init__.py
@@ -30,6 +30,7 @@ store_mnemonics = [
     "sw",
     "swl",
     "swr",
+    "nor",
 ]
 
 single_reg_loads = [

--- a/maspsx/__init__.py
+++ b/maspsx/__init__.py
@@ -30,7 +30,6 @@ store_mnemonics = [
     "sw",
     "swl",
     "swr",
-    "nor",
 ]
 
 single_reg_loads = [
@@ -41,6 +40,7 @@ single_reg_loads = [
     "rem",
     "move",
     "negu",
+    "nor",
 ]
 double_reg_loads = [
     "and",


### PR DESCRIPTION
As part of SOTN Decomp, I was working on this function. It matches, aside from the missing NOP at assembly address 1F8.

https://decomp.me/scratch/aYRXv

It appears that when loading $v0, then applying a `nor` to it (in this case, `nor` with 0 to invert all the bits), a `nop` is needed in between. Changing the compiler to PSYQ3.5 properly adds the `nop` to the compiled assembly and results in a perfect match.

Testing locally (with this function's code copied over), adding `nor` to the `store_mnemonics` list fixed this issue. 

I am not sure if there is a different list that `nor` should go into (since it's not a store mnemonic), or if `store_mnemonics` should be renamed now that we have found a non-storage instance where that `nop` is needed. So this PR may need to be adjusted, but at least this is a starting point toward a solution for this issue.