### PR TITLE
Don't use gprel with offset for older aspsx

### DIFF
--- a/aspsx/ASM/GP_OFFST.S
+++ b/aspsx/ASM/GP_OFFST.S
@@ -1,0 +1,2 @@
+.comm	spuCommonAttr,40
+lw	$4,spuCommonAttr+8

--- a/aspsx/ASM/LA.S
+++ b/aspsx/ASM/LA.S
@@ -1,0 +1,2 @@
+.comm	spuCommonAttr,40
+la	$4,spuCommonAttr

--- a/aspsx/test_gp_offset.py
+++ b/aspsx/test_gp_offset.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+import unittest
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import util
+
+GP_OFFSET_TEST_RESULT_NO_GP = [
+    '0x3C040000',   # lui         $a0, 0x0
+    '0x8C840000',   # lw          $a0, 0x0($a0)
+]
+
+GP_OFFSET_TEST_RESULT_GP = [
+    '0x8F840000',   # addiu       $a0, $gp, 0x0
+]
+
+TESTS = {
+    "source_asm": "ASM/GP_OFFST.S",
+    "versions": [
+        {
+            "aspsx_version": "2.21",
+            "target_asm": GP_OFFSET_TEST_RESULT_NO_GP,
+        },
+        {
+            "aspsx_version": "2.34",
+            "target_asm": GP_OFFSET_TEST_RESULT_NO_GP,
+        },
+        {
+            "aspsx_version": "2.56",
+            "target_asm": GP_OFFSET_TEST_RESULT_NO_GP,
+        },
+        {
+            "aspsx_version": "2.67",
+            "target_asm": GP_OFFSET_TEST_RESULT_NO_GP,
+        },
+        {
+            "aspsx_version": "2.77",
+            "target_asm": GP_OFFSET_TEST_RESULT_GP,
+        },
+        {
+            "aspsx_version": "2.79",
+            "target_asm": GP_OFFSET_TEST_RESULT_GP,
+        },
+        {
+            "aspsx_version": "2.81",
+            "target_asm": GP_OFFSET_TEST_RESULT_GP,
+        },
+        {
+            "aspsx_version": "2.86",
+            "target_asm": GP_OFFSET_TEST_RESULT_GP,
+        },
+    ],
+}
+
+
+class TestGoOffset(unittest.TestCase):
+    def test_sltu_at(self):
+        source_asm: Path = Path(__file__).parent / TESTS["source_asm"]
+
+        for version in TESTS["versions"]:
+            with self.subTest(version=version):
+                target_asm = version["target_asm"]
+                print(f"{source_asm.name}: {version['aspsx_version']}")
+                instructions = util.run_aspsx(source_asm, version, data_limit="-G999")
+                self.assertEqual(target_asm, instructions)

--- a/aspsx/test_la.py
+++ b/aspsx/test_la.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+import unittest
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import util
+
+LA_TEST_RESULT_NO_GP = [
+    '0x3C040000',   # lui         $a0, 0x0
+    '0x24840000',   # addiu       $a0, $a0, 0x0
+]
+
+LA_TEST_RESULT_GP = [
+    '0x27840000',   # addiu       $a0, $gp, 0x0
+]
+
+TESTS = {
+    "source_asm": "ASM/LA.S",
+    "versions": [
+        {
+            "aspsx_version": "2.21",
+            "target_asm": LA_TEST_RESULT_NO_GP,
+        },
+        {
+            "aspsx_version": "2.34",
+            "target_asm": LA_TEST_RESULT_NO_GP,
+        },
+        {
+            "aspsx_version": "2.56",
+            "target_asm": LA_TEST_RESULT_NO_GP,
+        },
+        {
+            "aspsx_version": "2.67",
+            "target_asm": LA_TEST_RESULT_NO_GP,
+        },
+        {
+            "aspsx_version": "2.77",
+            "target_asm": LA_TEST_RESULT_NO_GP,
+        },
+        {
+            "aspsx_version": "2.79",
+            "target_asm": LA_TEST_RESULT_NO_GP,
+        },
+        {
+            "aspsx_version": "2.81",
+            "target_asm": LA_TEST_RESULT_GP,
+        },
+        {
+            "aspsx_version": "2.86",
+            "target_asm": LA_TEST_RESULT_GP,
+        },
+    ],
+}
+
+
+class TestLa(unittest.TestCase):
+    def test_sltu_at(self):
+        source_asm: Path = Path(__file__).parent / TESTS["source_asm"]
+
+        for version in TESTS["versions"]:
+            with self.subTest(version=version):
+                target_asm = version["target_asm"]
+                print(f"{source_asm.name}: {version['aspsx_version']}")
+                instructions = util.run_aspsx(source_asm, version, data_limit="-G999")
+                self.assertEqual(target_asm, instructions)

--- a/maspsx.py
+++ b/maspsx.py
@@ -67,6 +67,7 @@ def main():
     nop_v0_at = False
     sltu_at = True
     expand_li = True
+    gprel_with_offset_allowed = False
 
     if args.aspsx_version:
         aspsx_version = tuple(int(x) for x in args.aspsx_version.split("."))
@@ -76,6 +77,7 @@ def main():
             expand_li = False
         if aspsx_version >= (2, 77):
             sltu_at = False
+            gprel_with_offset_allowed = True
 
     if args.dont_expand_li and expand_li:
         expand_li = False
@@ -87,6 +89,7 @@ def main():
         expand_li=expand_li,
         nop_v0_at=nop_v0_at,
         sltu_at=sltu_at,
+        gprel_with_offset_allowed=gprel_with_offset_allowed,
     )
     try:
         out_lines = maspsx_processor.process_lines()

--- a/maspsx.py
+++ b/maspsx.py
@@ -64,10 +64,11 @@ def main():
         if arg.startswith("-G") and len(arg) > 2:
             sdata_limit = int(arg[2:])
 
-    nop_v0_at = False
-    sltu_at = True
-    expand_li = True
-    gprel_with_offset_allowed = False
+    nop_v0_at = False         # insert nop between v0/at?
+    sltu_at = True            # sltu uses at?
+    expand_li = True          # turn li into liu/ori
+    gp_allow_offset = False   # use gp for sym+offset?
+    gp_allow_la = False       # use gp for la
 
     if args.aspsx_version:
         aspsx_version = tuple(int(x) for x in args.aspsx_version.split("."))
@@ -77,7 +78,9 @@ def main():
             expand_li = False
         if aspsx_version >= (2, 77):
             sltu_at = False
-            gprel_with_offset_allowed = True
+            gp_allow_offset = True
+        if aspsx_version >= (2, 81):
+            gp_allow_la = True
 
     if args.dont_expand_li and expand_li:
         expand_li = False
@@ -89,7 +92,8 @@ def main():
         expand_li=expand_li,
         nop_v0_at=nop_v0_at,
         sltu_at=sltu_at,
-        gprel_with_offset_allowed=gprel_with_offset_allowed,
+        gp_allow_offset=gp_allow_offset,
+        gp_allow_la=gp_allow_la,
     )
     try:
         out_lines = maspsx_processor.process_lines()

--- a/tests/test_gp_rel.py
+++ b/tests/test_gp_rel.py
@@ -20,6 +20,7 @@ class TestGpRel(unittest.TestCase):
         mp = MaspsxProcessor(
             lines,
             sdata_limit=65536,
+            gp_allow_offset=True,
         )
         res = mp.process_lines()
 
@@ -40,6 +41,7 @@ class TestGpRel(unittest.TestCase):
         mp = MaspsxProcessor(
             lines,
             sdata_limit=65536,
+            gp_allow_offset=True,
         )
         res = mp.process_lines()
 
@@ -61,31 +63,51 @@ class TestGpRel(unittest.TestCase):
         mp = MaspsxProcessor(
             lines,
             sdata_limit=65536,
+            gp_allow_offset=True,
+            gp_allow_la=True,
         )
         res = mp.process_lines()
 
         clean_lines = strip_comments(res)
         self.assertEqual(expected_lines, clean_lines[:1])
 
-    # This test is commented out until futher understood
-    #
-    # def test_gp_rel_load_address_no_offset(self):
-    #     """
-    #     https://decomp.me/scratch/AcqnS does not use %gp_rel for accessing the struct.
-    #     """
-    #     lines = [
-    #         "	.lcomm	DefaultStateTable,248",
-    #         "	la	$2,DefaultStateTable",
-    #     ]
-    #     expected_lines = [
-    #         "la\t$2,DefaultStateTable",
-    #     ]
+    def test_gp_rel_load_address_gp_allow_la_false(self):
+        """
+        https://decomp.me/scratch/AcqnS does not use %gp_rel for accessing the struct.
+        """
+        lines = [
+            "	.lcomm	DefaultStateTable,248",
+            "	la	$2,DefaultStateTable",
+        ]
+        expected_lines = [
+            "la\t$2,DefaultStateTable",
+        ]
 
-    #     mp = MaspsxProcessor(
-    #         lines,
-    #         sdata_limit=65536,
-    #     )
-    #     res = mp.process_lines()
+        mp = MaspsxProcessor(
+            lines,
+            sdata_limit=65536,
+            gp_allow_la=False,
+        )
+        res = mp.process_lines()
 
-    #     clean_lines = strip_comments(res)
-    #     self.assertEqual(expected_lines, clean_lines[:1])
+        clean_lines = strip_comments(res)
+        self.assertEqual(expected_lines, clean_lines[:1])
+
+    def test_gp_rel_load_address_gp_allow_la_true(self):
+        lines = [
+            "	.lcomm	DefaultStateTable,248",
+            "	la	$2,DefaultStateTable",
+        ]
+        expected_lines = [
+            "la\t$2,%gp_rel(DefaultStateTable)($gp)",
+        ]
+
+        mp = MaspsxProcessor(
+            lines,
+            sdata_limit=65536,
+            gp_allow_la=True,
+        )
+        res = mp.process_lines()
+
+        clean_lines = strip_comments(res)
+        self.assertEqual(expected_lines, clean_lines[:1])

--- a/tests/test_nop.py
+++ b/tests/test_nop.py
@@ -275,9 +275,6 @@ class TestNop(unittest.TestCase):
         ]
         mp = MaspsxProcessor(lines)
         res = mp.process_lines()
-        for line in res:
-            print(line)
-
         clean_lines = strip_comments(res)
         self.assertEqual(expected_lines, clean_lines[:2])
 
@@ -297,9 +294,6 @@ class TestNop(unittest.TestCase):
         ]
         mp = MaspsxProcessor(lines)
         res = mp.process_lines()
-        for line in res:
-            print(line)
-
         clean_lines = strip_comments(res)
         self.assertEqual(expected_lines, clean_lines[:2])
 
@@ -391,7 +385,7 @@ class TestNop(unittest.TestCase):
             "nop",
             "sw\t$2,%gp_rel(gameTrackerX+576)($gp)",
         ]
-        mp = MaspsxProcessor(lines, sdata_limit=1024)
+        mp = MaspsxProcessor(lines, sdata_limit=1024, gp_allow_offset=True)
         res = mp.process_lines()
         clean_lines = strip_comments(res)
         self.assertEqual(expected_lines, clean_lines[:4])


### PR DESCRIPTION
Older versions of aspsx don't seem to use GP-relative addressing for symbol + offset addresses. Here's a scratch demonstrating the problem: https://decomp.me/scratch/5pMP2

The behaviour seems to have changed between 2.67 and 2.77. Diff of DUMPOBJ.EXE for the objects assembled from the same source shows:

````
--- aspsx-2.67.txt	2024-03-21 00:10:12.529671553 +0200
+++ aspsx-2.77.txt	2024-03-21 00:10:01.209671224 +0200
@@ -1,40 +1,35 @@
 Header : LNK version 2
 46 : Processor type 7
 16 : Section symbol number 1 '.rdata' in group 0 alignment 8
 16 : Section symbol number 2 '.text' in group 0 alignment 8
 16 : Section symbol number 3 '.data' in group 0 alignment 8
 16 : Section symbol number 4 '.sdata' in group 0 alignment 8
 16 : Section symbol number 5 '.sbss' in group 0 alignment 8
 16 : Section symbol number 6 '.bss' in group 0 alignment 8
 16 : Section symbol number 7 '.ctors' in group 0 alignment 8
 16 : Section symbol number 8 '.dtors' in group 0 alignment 8
 6 : Switch to section 2
-2 : Code 192 bytes
-10 : Patch type 30 at offset 4 with (sectstart(4)-[d])
-10 : Patch type 30 at offset 8 with (sectstart(4)-[c])
-10 : Patch type 30 at offset 10 with (sectstart(4)-[b])
-10 : Patch type 82 at offset 18 with ($4+[b])
-10 : Patch type 84 at offset 1c with ($4+[b])
-10 : Patch type 82 at offset 20 with ($6+[b])
-10 : Patch type 84 at offset 24 with ($6+[b])
-10 : Patch type 82 at offset 7c with [b]
-10 : Patch type 84 at offset 80 with [b]
-10 : Patch type 82 at offset 84 with ($18+[b])
-10 : Patch type 84 at offset 88 with ($18+[b])
-10 : Patch type 82 at offset 98 with ($10+[b])
-10 : Patch type 84 at offset 9c with ($10+[b])
-10 : Patch type 82 at offset a0 with ($12+[b])
-10 : Patch type 84 at offset a4 with ($12+[b])
-10 : Patch type 74 at offset a8 with [e]
+2 : Code 172 bytes
+10 : Patch type 100 at offset 4 with [d]
+10 : Patch type 100 at offset 8 with [c]
+10 : Patch type 100 at offset 10 with [b]
+10 : Patch type 100 at offset 18 with ($4+[b])
+10 : Patch type 100 at offset 1c with ($6+[b])
+10 : Patch type 82 at offset 74 with [b]
+10 : Patch type 84 at offset 78 with [b]
+10 : Patch type 100 at offset 7c with ($18+[b])
+10 : Patch type 100 at offset 8c with ($10+[b])
+10 : Patch type 100 at offset 90 with ($12+[b])
+10 : Patch type 74 at offset 94 with [e]
 6 : Switch to section 2
 48 : XBSS symbol number b 'spuCommonAttr' size 28 in section 5
 14 : XREF symbol number e 'SpuSetCommonAttr'
 48 : XBSS symbol number d 'musicVolume' size 4 in section 5
 12 : XDEF symbol number a 'SndSetMusicVolume' at offset 0 in section 2
 48 : XBSS symbol number c 'playingBonusMusic' size 2 in section 5
 0 : End of file
````

I guess they have introduced entire new relocation type for gprel addressing where the old one couldn't support offsets. (30 is also a type not supported by psyq-obj-parser).