### PR TITLE
Further gprel sym+offset fixes

### DIFF
--- a/aspsx/ASM/GP_OFFST.S
+++ b/aspsx/ASM/GP_OFFST.S
@@ -1,2 +1,5 @@
-.comm	spuCommonAttr,40
-lw	$4,spuCommonAttr+8
+.comm	commonVar,40
+.lcomm	localCommonVar,40
+
+lw	$4,commonVar+8
+lw	$6,localCommonVar+4

--- a/aspsx/test_gp_offset.py
+++ b/aspsx/test_gp_offset.py
@@ -8,12 +8,18 @@ sys.path.insert(0, str(Path(__file__).parent))
 import util
 
 GP_OFFSET_TEST_RESULT_NO_GP = [
+    # comm
     "0x3C040000",  # lui         $a0, 0x0
     "0x8C840000",  # lw          $a0, 0x0($a0)
+    # lcomm
+    "0x8F860000",  # lw          $a2, 0x0($gp)
 ]
 
 GP_OFFSET_TEST_RESULT_GP = [
-    "0x8F840000",  # addiu       $a0, $gp, 0x0
+    # comm
+    "0x8F840000",  # lw          $a0, 0x0($gp)
+    # lcomm
+    "0x8F860000",  # lw          $a2, 0x0($gp)
 ]
 
 TESTS = {

--- a/maspsx/__init__.py
+++ b/maspsx/__init__.py
@@ -412,6 +412,8 @@ class MaspsxProcessor:
                         current_symbol = line.replace(":", "")
                         self.sdata_entries[current_symbol] = 0
                     else:
+                        if line == "":
+                            continue
                         if line.startswith(".type"):
                             continue
 

--- a/tests/test_gp_rel.py
+++ b/tests/test_gp_rel.py
@@ -48,6 +48,54 @@ class TestGpRel(unittest.TestCase):
         clean_lines = strip_comments(res)
         self.assertEqual(expected_lines, clean_lines[:2])
 
+    def test_gp_rel_load_with_offset_not_allowed_lcomm(self):
+        lines = [
+            "	.lcomm	savedInfoTracker,16",
+            "	lw	$4,savedInfoTracker+4",
+            "	lw	$2,savedInfoTracker+8",
+        ]
+        expected_lines = [
+            "lw\t$4,%gp_rel(savedInfoTracker+4)($gp)",
+            "lw\t$2,%gp_rel(savedInfoTracker+8)($gp)",
+        ]
+
+        mp = MaspsxProcessor(
+            lines,
+            sdata_limit=65536,
+            gp_allow_offset=False,
+        )
+        res = mp.process_lines()
+
+        clean_lines = strip_comments(res)
+        self.assertEqual(expected_lines, clean_lines[:2])
+
+    def test_gp_rel_load_with_offset_not_allowed_sdata(self):
+        lines = [
+            "	.sdata",
+            "	savedInfoTracker:",
+            "	.word	1",
+            "	.word	2",
+            "	.word	3",
+            "	.word	4",
+            "	.section .text",
+            "	lw	$4,savedInfoTracker+4",
+            "	lw	$2,savedInfoTracker+8",
+        ]
+        expected_lines = [
+            "lw\t$4,%gp_rel(savedInfoTracker+4)($gp)",
+            "lw\t$2,%gp_rel(savedInfoTracker+8)($gp)",
+        ]
+
+        mp = MaspsxProcessor(
+            lines,
+            sdata_limit=65536,
+            gp_allow_offset=False,
+        )
+        res = mp.process_lines()
+
+        clean_lines = strip_comments(res)
+        self.assertEqual(expected_lines, clean_lines[-2:])
+
     def test_gp_rel_store_with_offset(self):
         lines = [
             "	.comm	savedInfoTracker,16",
@@ -74,7 +122,7 @@ class TestGpRel(unittest.TestCase):
         https://decomp.me/scratch/X5k0K uses %gp_rel for accessing the Raziel struct
         """
         lines = [
-            "	.lcomm	Raziel,1464",
+            "	.comm	Raziel,1464",
             "	la	$5,Raziel+1380",
         ]
         expected_lines = [
@@ -97,7 +145,7 @@ class TestGpRel(unittest.TestCase):
         https://decomp.me/scratch/X5k0K uses %gp_rel for accessing the Raziel struct
         """
         lines = [
-            "	.lcomm	Raziel,1464",
+            "	.comm	Raziel,1464",
             "	la	$5,Raziel+1380",
         ]
         expected_lines = [
@@ -120,7 +168,7 @@ class TestGpRel(unittest.TestCase):
         https://decomp.me/scratch/AcqnS does not use %gp_rel for accessing the struct.
         """
         lines = [
-            "	.lcomm	DefaultStateTable,248",
+            "	.comm	DefaultStateTable,248",
             "	la	$2,DefaultStateTable",
         ]
         expected_lines = [
@@ -139,7 +187,7 @@ class TestGpRel(unittest.TestCase):
 
     def test_gp_rel_load_address_gp_allow_la_true(self):
         lines = [
-            "	.lcomm	DefaultStateTable,248",
+            "	.comm	DefaultStateTable,248",
             "	la	$2,DefaultStateTable",
         ]
         expected_lines = [


### PR DESCRIPTION
The previous logic for whether to allow gp addressing for symbol+offset
seems incomplete. I tested this C with `vec` declared in different ways:

````
extern VECTOR vec;
void Test(SVECTOR* v) {
    vec.vx = v->vx;
    vec.vy = v->vy;
    vec.vz = v->vz;
}
````

and results for gcc 2.7.2.SN32.3.7.0002 + aspsx 2.56 are:

````
C variable type                    | gp used?        | asm declaration
-----------------------------------+-----------------+---------------------------
extern                             | never           | .extern vec, 16
func static initialized            | always          | .sdata; vec.2: .word 1,2,3
func static uninitialized          | always          | .lcomm vec.2,16
global static initialized          | always          | .sdata; vec: .word 1,2,3
global static uninitialized        | always          | .lcomm vec,16
global initialized                 | always          | .sdata; vec: .word 1,2,3
global uninitialized               | only w/o offset | .comm vec,16
global uninitialized w/-fno-common | always          | .sdata; vec: .space 16
````

so it seems only symbols declared with .comm shouldn't be allowed to use
offset in older aspsx.