### PR TITLE
Add option for making .lcomm symbols common

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,12 @@ If you need `maspsx` to expand `div/divu` and `rem/remu` ops, pass `--expand-div
 Get `maspsx` to add an `include "macro.inc"` statement to the output.
 
 ### `--use-comm-section`
-Put any common symbols in the `.comm` section
+Put any common symbols (in C, this means non-`static` global variables without an initializer) in the `.comm` section (which is the default ccpsx behaviour).
+
+### `--use-comm-for-lcomm`
+Also put `.lcomm`-declared symbols (in C, this means `static` variables without an initializer) in the `.comm` section.
+This can be convenient with games using `-G` in situations where a variable needs to be marked `static` to get code generation to match, but you don't want to migrate `.sdata`/`.sbss` to that .c file yet.
+Do note that this also makes the symbols global (unlike what `static` normally does).
 
 ### `-G`
 **EXPERIMENTAL** If your project uses `$gp`, maspsx needs to be explicitly passed a non-zero value for `-G`.

--- a/maspsx.py
+++ b/maspsx.py
@@ -18,6 +18,7 @@ def main() -> None:
     parser.add_argument("--dont-expand-li", action="store_true")
     parser.add_argument("--force-stdin", action="store_true")
     parser.add_argument("--use-comm-section", action="store_true")
+    parser.add_argument("--use-comm-for-lcomm", action="store_true")
     # deprecated
     parser.add_argument("--no-macro-inc", action="store_true")
     parser.add_argument("--expand-li", action="store_true")
@@ -112,6 +113,7 @@ def main() -> None:
         gp_allow_offset=gp_allow_offset,
         gp_allow_la=gp_allow_la,
         use_comm_section=args.use_comm_section,
+        use_comm_for_lcomm=args.use_comm_for_lcomm,
     )
     try:
         out_lines = maspsx_processor.process_lines()

--- a/maspsx/__init__.py
+++ b/maspsx/__init__.py
@@ -370,6 +370,7 @@ class MaspsxProcessor:
         gp_allow_offset=False,
         gp_allow_la=False,
         use_comm_section=False,
+        use_comm_for_lcomm=False,
     ):
         self.lines = [x.strip() for x in lines]
 
@@ -386,6 +387,7 @@ class MaspsxProcessor:
         self.gp_allow_la = gp_allow_la
 
         self.use_comm_section = use_comm_section
+        self.use_comm_for_lcomm = use_comm_for_lcomm
 
         self.bss_entries: dict[str, int] = {}
         self.sbss_entries: dict[str, int] = {}
@@ -509,7 +511,7 @@ class MaspsxProcessor:
                 if i == 0:
                     res.append(f".section .{section}")
 
-                if self.use_comm_section and symbol in self.comm_symbols:
+                if self.use_comm_section and (symbol in self.comm_symbols or self.use_comm_for_lcomm):
                     # default to 1-byte alignment for COMMON
                     res.append(f"\t.comm {symbol},{size},1")
                     continue


### PR DESCRIPTION
This can be convenient with games using `-G` with older aspsx where static vs. non-static symbols cause different code generation.

Without this, if you run into a function which refers to a symbol that must be marked static to get the code generation correct, the only option is to migrate .sdata/.sbss for the C file containing it.

With the --use-comm-for-lcomm option that isn't necessary and the usual way of putting the address of the variable to symbols.txt still works.